### PR TITLE
Check it with a Scoped DbContext

### DIFF
--- a/WebEFCoreApp/Program.cs
+++ b/WebEFCoreApp/Program.cs
@@ -37,7 +37,7 @@ builder.Services.AddScoped<DashboardConfigurator>((IServiceProvider serviceProvi
 
     return configurator;
 });
-builder.Services.AddDbContext<OrdersContext>(options => options.UseSqlite("Data Source=file:Data/nwind.db"), ServiceLifetime.Transient);
+builder.Services.AddDbContext<OrdersContext>(options => options.UseSqlite("Data Source=file:Data/nwind.db"));
 var app = builder.Build();
 
 


### PR DESCRIPTION
DbContext are mostly Scoped instead of transient.

The new `SetEFContextProvider` brokes with a Scoped DbContext cause it is reused multiple tiemes